### PR TITLE
Add missing step during web app setup

### DIFF
--- a/docs/how-install-source-pythonanywhere.md
+++ b/docs/how-install-source-pythonanywhere.md
@@ -178,13 +178,12 @@ You're shown a message saying `All done! Your web app is now set up. Details bel
 
 * Click the URL next to **Source Code**. It is made editable. Make sure the end contains your URL followed by `/py4web` intead of `/mysite`. 
 Replace `your_username` in the following example with your PythonAnywhere username, and after typing in the correct values
-**be sure to click the checkmark button** to confirm your changes:
+**be sure to click the checkmark button** to confirm your changes. Then, do the same thing for **Working Directory**:
 
 ```
-# 1. Replace your_username with your own PythonAnywhere username
-# 2. Replace mysite with py4web
-# 3. BE SURE to click the checkmark to confirm your change!
-/home/your_username/py4web
+Source code: /home/your_username/py4web
+
+Working directory: /home/your_username/py4web
 ```
 
 * Do the same for **Working directory**.


### PR DESCRIPTION
This drove me crazy for a while, where my app wouldn't work. I figured out that both the Source code directory and the Working directory had to both point to the /home/your_username/py4web path.